### PR TITLE
Update planfile.ts - add missing possible change.actions values

### DIFF
--- a/src/planfile.ts
+++ b/src/planfile.ts
@@ -18,9 +18,11 @@ const planfileSchema = z.object({
         actions: z.union([
           z.tuple([z.literal('no-op')]),
           z.tuple([z.literal('create')]),
+          z.tuple([z.literal('read')]),
           z.tuple([z.literal('delete')]),
           z.tuple([z.literal('update')]),
           z.tuple([z.literal('delete'), z.literal('create')])
+          z.tuple([z.literal('create'), z.literal('delete')])
         ])
       })
     })


### PR DESCRIPTION
https://developer.hashicorp.com/terraform/internals/json-format#change-representation has two entries in change.actions that aren't currently in the definition for planfileSchema: ['read'] and ['create', 'delete'].

This commit adds those to the Zod definition.
